### PR TITLE
feat(resources): implement full CRUD operations (#81)

### DIFF
--- a/lib/contracts/src/index.ts
+++ b/lib/contracts/src/index.ts
@@ -3,3 +3,4 @@ export * from './auth/login';
 export * from './users';
 export * from './categories';
 export * from './tags';
+export * from './resources';

--- a/lib/contracts/src/resources/index.ts
+++ b/lib/contracts/src/resources/index.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+
+// ============================================
+// Resource Types
+// ============================================
+
+export const ResourceTypeSchema = z.enum([
+  'link',
+  'document',
+  'contact',
+  'event',
+  'note',
+]);
+
+export type ResourceType = z.infer<typeof ResourceTypeSchema>;
+
+// ============================================
+// Content Schemas by Type
+// ============================================
+
+export const LinkContentSchema = z.object({
+  url: z.string().url('Invalid URL format'),
+});
+
+export const DocumentContentSchema = z.object({
+  filePath: z.string().min(1, 'File path is required'),
+  mimeType: z.string().min(1, 'MIME type is required'),
+});
+
+export const ContactContentSchema = z.object({
+  email: z.string().email('Invalid email format').optional(),
+  phone: z.string().optional(),
+  company: z.string().optional(),
+});
+
+export const EventContentSchema = z.object({
+  eventDate: z.string().datetime('Invalid date format'),
+  location: z.string().optional(),
+});
+
+export const NoteContentSchema = z.object({
+  content: z.string().min(1, 'Note content is required'),
+});
+
+// ============================================
+// DTOs
+// ============================================
+
+export interface CreateResourceDto {
+  title: string;
+  description?: string;
+  type: ResourceType;
+  content: Record<string, unknown>;
+  categoryId?: string;
+  tagIds?: string[];
+}
+
+export interface UpdateResourceDto {
+  title?: string;
+  description?: string | null;
+  content?: Record<string, unknown>;
+  categoryId?: string | null;
+  tagIds?: string[];
+  isFavorite?: boolean;
+}
+
+export interface ResourceQueryDto {
+  type?: ResourceType;
+  categoryId?: string;
+  tagIds?: string;
+  isFavorite?: boolean;
+  search?: string;
+  sortBy?: 'createdAt' | 'title';
+  sortOrder?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface ResourceResponse {
+  id: string;
+  title: string;
+  description: string | null;
+  type: ResourceType;
+  content: Record<string, unknown>;
+  isFavorite: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  category: {
+    id: string;
+    name: string;
+    color: string | null;
+  } | null;
+  tags: Array<{
+    id: string;
+    name: string;
+  }>;
+}
+
+export interface PaginatedResourceResponse {
+  data: ResourceResponse[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+// ============================================
+// Validation Schemas
+// ============================================
+
+export const CreateResourceDtoSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+  type: ResourceTypeSchema,
+  content: z.record(z.string(), z.unknown()),
+  categoryId: z.string().uuid().optional(),
+  tagIds: z.array(z.string().uuid()).optional(),
+});
+
+export const UpdateResourceDtoSchema = z.object({
+  title: z.string().min(1, 'Title is required').optional(),
+  description: z.string().optional().nullable(),
+  content: z.record(z.string(), z.unknown()).optional(),
+  categoryId: z.string().uuid().optional().nullable(),
+  tagIds: z.array(z.string().uuid()).optional(),
+  isFavorite: z.boolean().optional(),
+});
+
+export const ResourceQueryDtoSchema = z.object({
+  type: ResourceTypeSchema.optional(),
+  categoryId: z.string().uuid().optional(),
+  tagIds: z.string().optional(), // Comma-separated UUIDs
+  isFavorite: z.coerce.boolean().optional(),
+  search: z.string().optional(),
+  sortBy: z.enum(['createdAt', 'title']).optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+});
+
+export const ResourceResponseSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  description: z.string().nullable(),
+  type: ResourceTypeSchema,
+  content: z.record(z.string(), z.unknown()),
+  isFavorite: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  category: z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+    color: z.string().nullable(),
+  }).nullable(),
+  tags: z.array(z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+  })),
+});
+
+// Helper function to validate content based on type
+export function validateResourceContent(type: ResourceType, content: Record<string, unknown>) {
+  switch (type) {
+    case 'link':
+      return LinkContentSchema.parse(content);
+    case 'document':
+      return DocumentContentSchema.parse(content);
+    case 'contact':
+      return ContactContentSchema.parse(content);
+    case 'event':
+      return EventContentSchema.parse(content);
+    case 'note':
+      return NoteContentSchema.parse(content);
+    default:
+      throw new Error(`Unknown resource type: ${type}`);
+  }
+}

--- a/packages/backend/scripts/test-api.ts
+++ b/packages/backend/scripts/test-api.ts
@@ -1,0 +1,154 @@
+import { strict as assert } from 'node:assert';
+
+const API_URL = process.env.API_URL || 'http://localhost:3000';
+const EMAIL = `test-${Date.now()}@example.com`; // Unique email each run
+const PASSWORD = 'password123';
+const NAME = 'Test User';
+
+// Colors for console
+const green = (msg: string) => console.log(`\x1b[32m✅ ${msg}\x1b[0m`);
+const red = (msg: string) => console.log(`\x1b[31m❌ ${msg}\x1b[0m`);
+const info = (msg: string) => console.log(`\x1b[34mℹ️ ${msg}\x1b[0m`);
+
+async function request(path: string, method: string = 'GET', body?: any, token?: string) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_URL}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.json().catch(() => ({}));
+  
+  if (!res.ok) {
+    throw new Error(`${method} ${path} failed (${res.status}): ${JSON.stringify(data)}`);
+  }
+
+  return data;
+}
+
+async function main() {
+  info('Starting API Integration Tests...');
+  let token: string = '';
+  let userId: string = '';
+  let categoryId: string = '';
+  let tagId: string = '';
+  let resourceId: string = '';
+
+  try {
+    // 1. Register
+    info('1. Testing Register...');
+    const registerData = await request('/auth/register', 'POST', {
+      email: EMAIL,
+      password: PASSWORD,
+      username: NAME, // Mapped to name in backend
+    });
+    token = registerData.access_token;
+    green('Register successful');
+
+    // 2. Login
+    info('2. Testing Login...');
+    const loginData = await request('/auth/login', 'POST', {
+      username: EMAIL, // Mapped to email in backend
+      password: PASSWORD,
+    });
+    assert(loginData.access_token, 'No access token returned');
+    token = loginData.access_token; // Refresh token just in case
+    green('Login successful');
+
+    // 2.5 Get Me (to get User ID)
+    info('2.5. Testing Get Me...');
+    const meData = await request('/auth/me', 'GET', undefined, token);
+    userId = meData.id;
+    green('Get Me successful');
+
+    // 3. Create Category
+    info('3. Testing Create Category...');
+    const category = await request('/categories', 'POST', {
+      name: `Work ${Date.now()}`,
+      color: '#ff0000'
+    }, token);
+    categoryId = category.id;
+    green('Category created');
+
+    // 4. Create Tag
+    info('4. Testing Create Tag...');
+    const tag = await request('/tags', 'POST', {
+      name: `urgent-${Date.now()}`
+    }, token);
+    tagId = tag.id;
+    green('Tag created');
+
+    // 5. Create Resource (Link)
+    info('5. Testing Create Resource (Link)...');
+    const resource = await request('/resources', 'POST', {
+      title: 'My Awesome Link',
+      type: 'link',
+      content: { url: 'https://example.com' },
+      categoryId: categoryId,
+      tagIds: [tagId]
+    }, token);
+    resourceId = resource.id;
+    assert.equal(resource.title, 'My Awesome Link');
+    assert.equal(resource.type, 'link');
+    green('Resource created');
+
+    // 6. Get Resource
+    info('6. Testing Get Resource...');
+    const fetchedResource = await request(`/resources/${resourceId}`, 'GET', undefined, token);
+    assert.equal(fetchedResource.id, resourceId);
+    green('Get Resource successful');
+
+    // 7. Update Resource
+    info('7. Testing Update Resource...');
+    const updatedResource = await request(`/resources/${resourceId}`, 'PUT', {
+      title: 'Updated Title'
+    }, token);
+    assert.equal(updatedResource.title, 'Updated Title');
+    green('Update Resource successful');
+
+    // 8. Toggle Favorite
+    info('8. Testing Toggle Favorite...');
+    const favResource = await request(`/resources/${resourceId}/favorite`, 'PATCH', undefined, token);
+    assert.equal(favResource.isFavorite, true);
+    green('Toggle Favorite successful');
+
+    // 9. List Resources with filters
+    info('9. Testing List Resources...');
+    const list = await request('/resources?type=link&isFavorite=true', 'GET', undefined, token);
+    assert(list.data.length >= 1, 'Should find at least one resource');
+    green('List Resources successful');
+
+    // 10. Delete Resource
+    info('10. Testing Delete Resource...');
+    await request(`/resources/${resourceId}`, 'DELETE', undefined, token);
+    
+    // Verify deletion
+    try {
+        await request(`/resources/${resourceId}`, 'GET', undefined, token);
+        red('Resource should be deleted but was found');
+    } catch (e) {
+        green('Resource deleted successfully (404 returned as expected)');
+    }
+
+    // Cleanup (optional, but good for local dev repeated runs if we reused emails)
+    // await request(`/users/${userId}`, 'DELETE', undefined, token); // If user delete endpoint existed
+
+    console.log('\n');
+    console.log('\x1b[32m✨ All tests passed successfully! ✨\x1b[0m');
+
+  } catch (error: any) {
+    console.error('\n');
+    red('Test Failed!');
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/backend/src/resources/resources.controller.spec.ts
+++ b/packages/backend/src/resources/resources.controller.spec.ts
@@ -1,18 +1,118 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ResourcesController } from './resources.controller';
+import { ResourcesService } from './resources.service';
+import { CreateResourceDto, ResourceResponse } from 'contracts';
 
 describe('ResourcesController', () => {
   let controller: ResourcesController;
+  let service: ResourcesService;
+
+  const mockService = {
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockUser = {
+    userId: '550e8400-e29b-41d4-a716-446655440000',
+    email: 'test@example.com',
+  };
+  const mockResourceId = '550e8400-e29b-41d4-a716-446655440001';
+
+  const mockResource: ResourceResponse = {
+    id: mockResourceId,
+    title: 'Test Resource',
+    description: null,
+    type: 'link',
+    content: { url: 'https://example.com' },
+    isFavorite: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    category: null,
+    tags: [],
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ResourcesController],
+      providers: [
+        {
+          provide: ResourcesService,
+          useValue: mockService,
+        },
+      ],
     }).compile();
 
     controller = module.get<ResourcesController>(ResourcesController);
+    service = module.get<ResourcesService>(ResourcesService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should return paginated resources', async () => {
+      const mockResult = {
+        data: [mockResource],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      };
+      mockService.findAll.mockResolvedValue(mockResult);
+
+      const result = await controller.findAll(mockUser, {});
+
+      expect(result).toBe(mockResult);
+    });
+  });
+
+  describe('create', () => {
+    const createDto: CreateResourceDto = {
+      title: 'New Resource',
+      type: 'link',
+      content: { url: 'https://test.com' },
+    };
+
+    it('should create a resource', async () => {
+      mockService.create.mockResolvedValue({
+        ...mockResource,
+        title: createDto.title,
+      });
+
+      const result = await controller.create(createDto, mockUser);
+
+      expect(result.title).toBe(createDto.title);
+      expect(service.create).toHaveBeenCalled();
+    });
+
+    it('should throw validation error for bad input', async () => {
+      const invalidDto: any = {
+        title: '', // Invalid empty title
+        type: 'link',
+        content: {}, // Invalid content for link
+      };
+
+      await expect(controller.create(invalidDto, mockUser)).rejects.toThrow();
+    });
+  });
+
+  describe('toggleFavorite', () => {
+    it('should toggle favorite status', async () => {
+      mockService.findOne.mockResolvedValue(mockResource); // currently false
+      mockService.update.mockResolvedValue({
+        ...mockResource,
+        isFavorite: true,
+      });
+
+      const result = await controller.toggleFavorite(mockResourceId, mockUser);
+
+      expect(result.isFavorite).toBe(true);
+      expect(service.update).toHaveBeenCalledWith(
+        mockResourceId,
+        mockUser.userId,
+        { isFavorite: true },
+      );
+    });
   });
 });

--- a/packages/backend/src/resources/resources.controller.ts
+++ b/packages/backend/src/resources/resources.controller.ts
@@ -1,4 +1,138 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Patch,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ResourcesService } from './resources.service';
+import {
+  CreateResourceDto,
+  CreateResourceDtoSchema,
+  UpdateResourceDto,
+  UpdateResourceDtoSchema,
+  ResourceQueryDtoSchema,
+  ResourceResponseSchema,
+} from 'contracts';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { GetUser } from '../auth/get-user.decorator';
+import { strict as assert } from 'node:assert';
 
 @Controller('resources')
-export class ResourcesController {}
+@UseGuards(JwtAuthGuard)
+export class ResourcesController {
+  constructor(private readonly resourcesService: ResourcesService) {}
+
+  /**
+   * GET /resources
+   * List resources with filters and pagination
+   */
+  @Get()
+  async findAll(@GetUser() user: { userId: string }, @Query() query: any) {
+    // Manually convert numbers/booleans for query generic object before parsing?
+    // Zod's coerce should handle strings from query params
+    const parsedQuery = ResourceQueryDtoSchema.parse(query);
+
+    const result = await this.resourcesService.findAll(
+      user.userId,
+      parsedQuery,
+    );
+
+    // Validate output? (Optional overhead, but good for strictness)
+    // For list endpoints, we might skip full Zod parse on every item for performance if confident
+    // But let's keep it safe initially.
+    // However, PaginatedResourceResponse logic is in service, let's just return result.
+    return result;
+  }
+
+  /**
+   * GET /resources/:id
+   * Get single resource
+   */
+  @Get(':id')
+  async findOne(@Param('id') id: string, @GetUser() user: { userId: string }) {
+    const resource = await this.resourcesService.findOne(id, user.userId);
+    assert(resource, new Error('Resource not found'));
+    return ResourceResponseSchema.parse(resource);
+  }
+
+  /**
+   * POST /resources
+   * Create resource
+   */
+  @Post()
+  async create(
+    @Body() createResourceDto: CreateResourceDto,
+    @GetUser() user: { userId: string },
+  ) {
+    const parsedDto = CreateResourceDtoSchema.parse(createResourceDto);
+    assert(parsedDto, new Error('Invalid resource data'));
+
+    const resource = await this.resourcesService.create(user.userId, parsedDto);
+    assert(resource, new Error('Failed to create resource'));
+
+    return ResourceResponseSchema.parse(resource);
+  }
+
+  /**
+   * PUT /resources/:id
+   * Update resource
+   */
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updateResourceDto: UpdateResourceDto,
+    @GetUser() user: { userId: string },
+  ) {
+    const parsedDto = UpdateResourceDtoSchema.parse(updateResourceDto);
+    assert(parsedDto, new Error('Invalid update data'));
+
+    const resource = await this.resourcesService.update(
+      id,
+      user.userId,
+      parsedDto,
+    );
+    assert(resource, new Error('Failed to update resource'));
+
+    return ResourceResponseSchema.parse(resource);
+  }
+
+  /**
+   * DELETE /resources/:id
+   * Delete resource
+   */
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @GetUser() user: { userId: string }) {
+    await this.resourcesService.remove(id, user.userId);
+  }
+
+  /**
+   * PATCH /resources/:id/favorite
+   * Toggle favorite status
+   */
+  @Patch(':id/favorite')
+  async toggleFavorite(
+    @Param('id') id: string,
+    @GetUser() user: { userId: string },
+  ) {
+    // First get current status
+    const resource = await this.resourcesService.findOne(id, user.userId);
+    // Toggle
+    const updated = await this.resourcesService.update(id, user.userId, {
+      isFavorite: !resource.isFavorite,
+    });
+
+    return {
+      id: updated.id,
+      isFavorite: updated.isFavorite,
+    };
+  }
+}

--- a/packages/backend/src/resources/resources.module.ts
+++ b/packages/backend/src/resources/resources.module.ts
@@ -4,6 +4,6 @@ import { ResourcesController } from './resources.controller';
 
 @Module({
   providers: [ResourcesService],
-  controllers: [ResourcesController]
+  controllers: [ResourcesController],
 })
 export class ResourcesModule {}

--- a/packages/backend/src/resources/resources.service.spec.ts
+++ b/packages/backend/src/resources/resources.service.spec.ts
@@ -1,18 +1,166 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ResourcesService } from './resources.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('ResourcesService', () => {
   let service: ResourcesService;
+  let prisma: PrismaService;
+
+  const mockPrismaService = {
+    resource: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    category: {
+      findFirst: jest.fn(),
+    },
+    tag: {
+      count: jest.fn(),
+    },
+    $transaction: jest.fn((args) => args),
+  };
+
+  // Mock data with valid UUIDs
+  const mockUserId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockResourceId = '550e8400-e29b-41d4-a716-446655440001';
+  const mockCategoryId = '550e8400-e29b-41d4-a716-446655440002';
+  const mockTagId = '550e8400-e29b-41d4-a716-446655440003';
+
+  // Raw Prisma response format
+  const mockDbResource = {
+    id: mockResourceId,
+    title: 'Test Resource',
+    type: 'link',
+    content: { url: 'https://example.com' },
+    isFavorite: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    category: {
+      id: mockCategoryId,
+      name: 'Work',
+      color: '#3B82F6',
+    },
+    tags: [
+      {
+        tag: {
+          id: mockTagId,
+          name: 'important',
+        },
+      },
+    ],
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ResourcesService],
+      providers: [
+        ResourcesService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
     }).compile();
 
     service = module.get<ResourcesService>(ResourcesService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should return paginated resources', async () => {
+      mockPrismaService.resource.count.mockResolvedValue(1);
+      mockPrismaService.resource.findMany.mockResolvedValue([mockDbResource]);
+      // Mock $transaction behavior
+      mockPrismaService.$transaction.mockResolvedValue([1, [mockDbResource]]);
+
+      const result = await service.findAll(mockUserId, {});
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe(mockResourceId);
+      expect(result.data[0].tags[0].name).toBe('important');
+      expect(result.pagination.total).toBe(1);
+    });
+  });
+
+  describe('create', () => {
+    const createDto = {
+      title: 'New Resource',
+      type: 'link' as const,
+      content: { url: 'https://google.com' },
+      categoryId: mockCategoryId,
+      tagIds: [mockTagId],
+    };
+
+    it('should create a resource with dependencies', async () => {
+      mockPrismaService.category.findFirst.mockResolvedValue({
+        id: mockCategoryId,
+      });
+      mockPrismaService.tag.count.mockResolvedValue(1); // 1 tag found
+      mockPrismaService.resource.create.mockResolvedValue({
+        ...mockDbResource,
+        title: 'New Resource',
+      });
+
+      const result = await service.create(mockUserId, createDto);
+
+      expect(result.title).toBe('New Resource');
+      expect(prisma.resource.create).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid content', async () => {
+      const invalidDto = {
+        ...createDto,
+        content: { invalid: 'content' },
+      };
+
+      await expect(service.create(mockUserId, invalidDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException if category not found', async () => {
+      mockPrismaService.category.findFirst.mockResolvedValue(null);
+
+      await expect(service.create(mockUserId, createDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a resource', async () => {
+      mockPrismaService.resource.findFirst.mockResolvedValue(mockDbResource);
+      mockPrismaService.resource.update.mockResolvedValue({
+        ...mockDbResource,
+        title: 'Updated Title',
+      });
+
+      const result = await service.update(mockResourceId, mockUserId, {
+        title: 'Updated Title',
+      });
+
+      expect(result.title).toBe('Updated Title');
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a resource', async () => {
+      mockPrismaService.resource.findFirst.mockResolvedValue(mockDbResource);
+      mockPrismaService.resource.delete.mockResolvedValue(mockDbResource);
+
+      await service.remove(mockResourceId, mockUserId);
+
+      expect(prisma.resource.delete).toHaveBeenCalledWith({
+        where: { id: mockResourceId },
+      });
+    });
   });
 });

--- a/packages/backend/src/resources/resources.service.ts
+++ b/packages/backend/src/resources/resources.service.ts
@@ -1,4 +1,321 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  CreateResourceDto,
+  UpdateResourceDto,
+  ResourceQueryDto,
+  PaginatedResourceResponse,
+  ResourceResponse,
+  ResourceType,
+  validateResourceContent,
+} from 'contracts';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
-export class ResourcesService {}
+export class ResourcesService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Helper to format generic Prisma result to ResourceResponse
+   */
+  private formatResource(resource: any): ResourceResponse {
+    return {
+      id: resource.id,
+      title: resource.title,
+      description: resource.description,
+      type: resource.type as ResourceType,
+      content: resource.content as Record<string, unknown>,
+      isFavorite: resource.isFavorite,
+      createdAt: resource.createdAt,
+      updatedAt: resource.updatedAt,
+      category: resource.category
+        ? {
+            id: resource.category.id,
+            name: resource.category.name,
+            color: resource.category.color,
+          }
+        : null,
+      tags: resource.tags.map((rt: any) => ({
+        id: rt.tag.id,
+        name: rt.tag.name,
+      })),
+    };
+  }
+
+  /**
+   * Create a new resource
+   */
+  async create(
+    userId: string,
+    createResourceDto: CreateResourceDto,
+  ): Promise<ResourceResponse> {
+    // Validate content structure based on type
+    try {
+      validateResourceContent(
+        createResourceDto.type,
+        createResourceDto.content,
+      );
+    } catch (error: any) {
+      throw new BadRequestException(
+        `Invalid content for type ${createResourceDto.type}: ${error.message}`,
+      );
+    }
+
+    // Verify category ownership if provided
+    if (createResourceDto.categoryId) {
+      const category = await this.prisma.category.findFirst({
+        where: { id: createResourceDto.categoryId, userId },
+      });
+      if (!category) {
+        throw new NotFoundException(
+          `Category with ID ${createResourceDto.categoryId} not found`,
+        );
+      }
+    }
+
+    // Verify tags ownership if provided
+    if (createResourceDto.tagIds && createResourceDto.tagIds.length > 0) {
+      const count = await this.prisma.tag.count({
+        where: {
+          id: { in: createResourceDto.tagIds },
+          userId,
+        },
+      });
+      if (count !== createResourceDto.tagIds.length) {
+        throw new NotFoundException('One or more tags not found');
+      }
+    }
+
+    const resource = await this.prisma.resource.create({
+      data: {
+        userId,
+        title: createResourceDto.title,
+        description: createResourceDto.description,
+        type: createResourceDto.type,
+        content: createResourceDto.content as Prisma.JsonObject,
+        categoryId: createResourceDto.categoryId,
+        tags: createResourceDto.tagIds
+          ? {
+              create: createResourceDto.tagIds.map((tagId) => ({
+                tag: { connect: { id: tagId } },
+              })),
+            }
+          : undefined,
+      },
+      include: {
+        category: true,
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    return this.formatResource(resource);
+  }
+
+  /**
+   * Find all resources with filters and pagination
+   */
+  async findAll(
+    userId: string,
+    query: ResourceQueryDto,
+  ): Promise<PaginatedResourceResponse> {
+    const {
+      type,
+      categoryId,
+      tagIds,
+      isFavorite,
+      search,
+      sortBy = 'createdAt',
+      sortOrder = 'desc',
+      page = 1,
+      limit = 20,
+    } = query;
+
+    const skip = (page - 1) * limit;
+
+    // Build where clause
+    const where: Prisma.ResourceWhereInput = {
+      userId,
+      ...(type && { type }),
+      ...(categoryId && { categoryId }),
+      ...(isFavorite !== undefined && { isFavorite }),
+    };
+
+    // Filter by tags (OR logic for now)
+    if (tagIds) {
+      const tagIdArray = tagIds.split(',').filter(Boolean);
+      if (tagIdArray.length > 0) {
+        where.tags = {
+          some: {
+            tagId: { in: tagIdArray },
+          },
+        };
+      }
+    }
+
+    // Search functionality
+    if (search) {
+      where.OR = [
+        { title: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    // Execute queries transactionally
+    const [total, resources] = await this.prisma.$transaction([
+      this.prisma.resource.count({ where }),
+      this.prisma.resource.findMany({
+        where,
+        include: {
+          category: true,
+          tags: {
+            include: {
+              tag: true,
+            },
+          },
+        },
+        orderBy: {
+          [sortBy]: sortOrder,
+        },
+        skip,
+        take: limit,
+      }),
+    ]);
+
+    return {
+      data: resources.map(this.formatResource),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Find one resource by ID
+   */
+  async findOne(id: string, userId: string): Promise<ResourceResponse> {
+    const resource = await this.prisma.resource.findFirst({
+      where: { id, userId },
+      include: {
+        category: true,
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    if (!resource) {
+      throw new NotFoundException(`Resource with ID ${id} not found`);
+    }
+
+    return this.formatResource(resource);
+  }
+
+  /**
+   * Update a resource
+   */
+  async update(
+    id: string,
+    userId: string,
+    updateResourceDto: UpdateResourceDto,
+  ): Promise<ResourceResponse> {
+    const existingResource = await this.prisma.resource.findFirst({
+      where: { id, userId },
+    });
+
+    if (!existingResource) {
+      throw new NotFoundException(`Resource with ID ${id} not found`);
+    }
+
+    // Validate content if provided
+    if (updateResourceDto.content) {
+      try {
+        validateResourceContent(
+          existingResource.type as ResourceType,
+          updateResourceDto.content,
+        );
+      } catch (error: any) {
+        throw new BadRequestException(`Invalid content: ${error.message}`);
+      }
+    }
+
+    // Prepare tags update
+    // For explicit M-N, it's easier to delete all and recreate, or strict diff
+    // But Prisma 'set' on nested relations is often easier if we were using implicit M-N.
+    // With explicit M-N, we might need deleteMany then create.
+    // However, Prisma supports 'deleteMany' and 'create' in update.
+
+    let tagsUpdate: any = undefined;
+    if (updateResourceDto.tagIds) {
+      // Verify tags
+      const count = await this.prisma.tag.count({
+        where: {
+          id: { in: updateResourceDto.tagIds },
+          userId,
+        },
+      });
+      if (count !== updateResourceDto.tagIds.length) {
+        throw new NotFoundException('One or more tags not found');
+      }
+
+      // Replace tags: Delete all existing links for this resource and create new ones
+      tagsUpdate = {
+        deleteMany: {},
+        create: updateResourceDto.tagIds.map((tagId) => ({
+          tag: { connect: { id: tagId } },
+        })),
+      };
+    }
+
+    const resource = await this.prisma.resource.update({
+      where: { id },
+      data: {
+        title: updateResourceDto.title,
+        description: updateResourceDto.description,
+        content: updateResourceDto.content as Prisma.JsonObject,
+        categoryId: updateResourceDto.categoryId,
+        isFavorite: updateResourceDto.isFavorite,
+        tags: tagsUpdate,
+      },
+      include: {
+        category: true,
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    return this.formatResource(resource);
+  }
+
+  /**
+   * Delete a resource
+   */
+  async remove(id: string, userId: string): Promise<void> {
+    const existingResource = await this.prisma.resource.findFirst({
+      where: { id, userId },
+    });
+
+    if (!existingResource) {
+      throw new NotFoundException(`Resource with ID ${id} not found`);
+    }
+
+    await this.prisma.resource.delete({
+      where: { id },
+    });
+  }
+}


### PR DESCRIPTION
# Description

Implémentation complète du CRUD pour le module [Resources](cci:2://file:///Users/esnaultjulien/projet-web-2026/packages/backend/src/resources/resources.service.ts:17:0-320:1), l'entité centrale de l'application.
Cette PR permet de gérer 5 types de ressources distincts (Lien, Document, Contact, Évènement, Note) avec une validation stricte du contenu pour chaque type.

Les fonctionnalités incluent :
- **Contrats** : DTOs et schémas Zod partagés pour le frontend.
- **Service** : Logique métier incluant pagination, recherche, et filtres avancés (tags, catégorie, favoris).
- **Controller** : Endpoints sécurisés par JWT.
- **Tests** : Couverture unitaire et script d'intégration.

Fixes #81

## Type de changement

- [ ] 🐛 Correction de bug (Bug fix)
- [x] ✨ Nouvelle fonctionnalité (New feature)
- [ ] 📚 Mise à jour de la documentation (Documentation update)
- [ ] ♻️ Refactoring (Amélioration du code sans changement fonctionnel)
- [ ] 🎨 Style (Mise en forme, CSS, etc.)
- [ ] 💥 Changement majeur (Breaking change)

## Comment cela a-t-il été testé ?

- [x] **Test unitaire** : 10 tests implémentés pour [ResourcesService](cci:2://file:///Users/esnaultjulien/projet-web-2026/packages/backend/src/resources/resources.service.ts:17:0-320:1) et [ResourcesController](cci:2://file:///Users/esnaultjulien/projet-web-2026/packages/backend/src/resources/resources.controller.ts:27:0-137:1) validant la logique et les erreurs (`npm run test`).
- [x] **Test d'intégration** : Script [scripts/test-api.ts](cci:7://file:///Users/esnaultjulien/projet-web-2026/packages/backend/scripts/test-api.ts:0:0-0:0) exécuté avec succès, validant le flux complet (Auth -> Création dépendances -> CRUD Resource).

## Checklist :

- [x] Mon code suit les guidelines du projet
- [x] J'ai relu mon propre code
- [x] J'ai commenté les parties complexes
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Mes changements ne génèrent pas de nouveaux avertissements (warnings)
- [x] J'ai ajouté des tests prouvant que ma correction/fonctionnalité marche